### PR TITLE
Fix a bug caused by multiple CSS files

### DIFF
--- a/scripts/build-format.js
+++ b/scripts/build-format.js
@@ -9,7 +9,7 @@ var twine = require('twine-utils');
 var encoding = { encoding: 'utf8' };
 
 Promise.all([
-	exec('cssnano src/*.css'),
+	exec('cat src/*.css | cssnano'),
 	exec('browserify -g uglifyify src/index.js', { maxBuffer: Infinity })
 ]).then(function(results) {
 	var distPath = 'dist/' + pkg.name.toLowerCase() + '-' + pkg.version;


### PR DESCRIPTION
Fix a bug caused by having multiple CSS files in the `src/` directory.

`cssnano` does not support globbing (ex. `src/*.css`). The second CSS file is actually being interpreted as an `output` argument causing it to be overwritten, and no output to be written to `stdout`.

To work around this, use `cat` to concatenate all CSS files to a single stream and pass _that_ to `cssnano`.