### PR TITLE
Add missing development dependency: onchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-source-map-support": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "onchange": "^3.3.0",
     "rimraf": "^2.6.1",
     "twine-utils": "^1.2.4",
     "uglifyify": "^3.0.4",


### PR DESCRIPTION
Add a missing development dependency: `onchange`. This is used for the `npm run start` task.